### PR TITLE
Fix transformers Rust compatibility: upgrade to 4.36.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -103,8 +103,8 @@ RUN pkg-config --exists openssl && echo "OpenSSL found" || echo "OpenSSL missing
 # Verify Rust installation
 RUN rustc --version
 
-RUN echo "Installing transformers 4.33.3 with system Rust compiler..." && \
-    pip install --no-cache-dir transformers==4.33.3 && \
+RUN echo "Installing transformers 4.36.0 (Python 3.12 compatible with prebuilt wheels)..." && \
+    pip install --no-cache-dir transformers==4.36.0 && \
     python3 -c "import transformers; print(f'✅ transformers: {transformers.__version__}')"
 
 RUN echo "Installing diffusers 0.21.4..." && \


### PR DESCRIPTION
- Update transformers from 4.33.3 to 4.36.0 for Python 3.12 compatibility
- Resolve tokenizers Rust compilation errors with newer Rust compiler
- Use version with prebuilt wheels to avoid unsafe casting patterns
- Maintains systematic ML dependency approach with compatible versions
- Should resolve 'casting &T to &mut T is undefined behavior' error