### PR TITLE
Fixed base64 image data containing Python byte string notation (b'...')

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# HEIC support deployment - v1.1
 FROM python:3.12-slim
 
 WORKDIR /app

--- a/frontend/src/components/VirtualTryOn.js
+++ b/frontend/src/components/VirtualTryOn.js
@@ -69,8 +69,15 @@ const VirtualTryOn = ({ user, onLogout }) => {
     }
 
     if (user.captured_image && !userImage) {
-      setUserImage(user.captured_image);
-      setUserImagePreview(user.captured_image);
+      let cleanImage = user.captured_image;
+      // Clean base64 data if it contains Python byte notation
+      if (cleanImage.includes("b'") || cleanImage.includes('b"')) {
+        cleanImage = cleanImage.replace(/^data:image\/[^;]+;base64,b['"]/, 'data:image/jpeg;base64,');
+        cleanImage = cleanImage.replace(/['"]$/, '');
+        cleanImage = cleanImage.replace(/\\x[0-9a-fA-F]{2}/g, '');
+      }
+      setUserImage(cleanImage);
+      setUserImagePreview(cleanImage);
     }
 
     if ((cameraFirst || (!user.captured_image && step === 0)) && step === 0) {
@@ -537,9 +544,17 @@ const VirtualTryOn = ({ user, onLogout }) => {
   const handleStandardImageFile = (file, type) => {
     const reader = new FileReader();
     reader.onload = (e) => {
-      const base64 = e.target.result;
+      let base64 = e.target.result;
       console.log('File read successfully, base64 length:', base64.length);
       console.log('Base64 preview:', base64.substring(0, 100) + '...');
+      
+      // Clean base64 data - remove Python byte string notation if present
+      if (base64.includes("b'") || base64.includes('b"')) {
+        console.log('Cleaning Python byte string notation from base64');
+        base64 = base64.replace(/^data:image\/[^;]+;base64,b['"]/, 'data:image/jpeg;base64,');
+        base64 = base64.replace(/['"]$/, '');
+        base64 = base64.replace(/\\x[0-9a-fA-F]{2}/g, '');
+      }
       
       if (!base64 || !base64.startsWith('data:image/')) {
         console.error('Invalid image data format');


### PR DESCRIPTION
Fixed the error caused by base64 image data containing Python byte string notation (b'...') which is invalid for HTML image sources. The fix:

Cleans malformed base64 data by removing Python byte string prefixes and suffixes

Removes escape sequences like \xff\xd8 that appear in the error

Applies cleaning both during file upload and when loading saved images

This will resolve the net::ERR_INVALID_URL error and allow images to display properly in the virtual try-on interface.